### PR TITLE
fix ConfigServer.conf config empty error

### DIFF
--- a/deploy/config/ConfigServer.conf
+++ b/deploy/config/ConfigServer.conf
@@ -6,7 +6,8 @@
     "server_name": "ConfigServer",
     "set_area": "",
     "set_group": "",
-    "set_name": "<Main>\n
+    "set_name": "",
+    "config": "<Main>\n
             <DB>\n
                 dbhost= dcache_host\n
                 dbpass= dcache_pass\n


### PR DESCRIPTION
There is no property config, and the value of `config` is set to `setname`