### PR TITLE
fix configserver parse conf error

### DIFF
--- a/deploy/config/ConfigServer.conf
+++ b/deploy/config/ConfigServer.conf
@@ -14,6 +14,6 @@
                 dbname= db_dcache_relation\n
                 charset=utf8mb4\n
                 dbport= dcache_port\n
-            </DB>
+            </DB>\n
         </Main>"
 }


### PR DESCRIPTION
fix config file parse error by adding `\n`