### PR TITLE
修复：创建应用时出错

### DIFF
--- a/src/OptServer/DCacheOptImp.cpp
+++ b/src/OptServer/DCacheOptImp.cpp
@@ -4595,6 +4595,7 @@ int DCacheOptImp::insertTarsServerTableWithIdcGroup(const string &sApp, const st
         m["posttime"]       = make_pair(TC_Mysql::DB_STR, TC_Common::now2str("%Y-%m-%d %H:%M:%S"));
         m["lastuser"]       = make_pair(TC_Mysql::DB_STR, "sys");
         m["tars_version"]   = make_pair(TC_Mysql::DB_STR, sTarsVersion);
+        m["server_type"]    = make_pair(TC_Mysql::DB_STR, "tars_cpp");
 
         // 这里默认开启IDC分组
         m["enable_group"] = make_pair(TC_Mysql::DB_STR,(enableGroup)?"Y":"N");//是否启用IDC分组
@@ -4650,6 +4651,7 @@ int DCacheOptImp::insertTarsServerTable(const string &sApp, const string &sServe
         m["lastuser"]       = make_pair(TC_Mysql::DB_STR, "sys");
         m["tars_version"]   = make_pair(TC_Mysql::DB_STR, sTarsVersion);
         m["enable_group"]   = make_pair(TC_Mysql::DB_STR, (enableGroup)?"Y":"N");//是否启用IDC分组
+        m["server_type"]    = make_pair(TC_Mysql::DB_STR, "tars_cpp");
 
         if (bReplace)
             _mysqlTarsDb.replaceRecord("t_server_conf", m);


### PR DESCRIPTION
## 问题

在按照[文档](https://github.com/TarsCloud/DCache/blob/b7b218fc12be02f4fdaa4931a7d0af5cf91d4955/docs/install.md#5.2)中的步骤部署和发布Proxy和Router服务时，点击“安装发布”按钮后出错，错误信息为：

```
cannot load server description from registry
```

## 分析

文件 [src\OptServer\DCacheOptImp.cpp](https://github.com/TarsCloud/DCache/blob/b7b218fc12be02f4fdaa4931a7d0af5cf91d4955/src/OptServer/DCacheOptImp.cpp) 中的两个函数 [DCacheOptImp::insertTarsServerTableWithIdcGroup()](https://github.com/TarsCloud/DCache/blob/b7b218fc12be02f4fdaa4931a7d0af5cf91d4955/src/OptServer/DCacheOptImp.cpp#L4585) 和 [DCacheOptImp::insertTarsServerTable()](https://github.com/TarsCloud/DCache/blob/b7b218fc12be02f4fdaa4931a7d0af5cf91d4955/src/OptServer/DCacheOptImp.cpp#L4639) 含有向数据库表`t_server_conf`插入记录的逻辑。

原来的逻辑中，插入记录时，字段`server_type`没有设置，这将导致插入的记录中此项为`NULL`.

在 [TarsFramework仓库](https://github.com/TarsCloud/TarsFramework) 的 [RegistryServer\DbHandle.cpp](https://github.com/TarsCloud/TarsFramework/blob/38d3683d77d0b5b0fa668ad3cbc057c113964c57/RegistryServer/DbHandle.cpp) 文件中的 [CDbHandle::getServers()](https://github.com/TarsCloud/TarsFramework/blob/38d3683d77d0b5b0fa668ad3cbc057c113964c57/RegistryServer/DbHandle.cpp#L239) 函数中，可看到SQL过滤条件：

```cpp
        //server详细配置
        string sCondition;
        sCondition += "server.node_name='" + _mysqlReg.escapeString(nodeName) + "'";
        if (app != "")        sCondition += " and server.application='" + _mysqlReg.escapeString(app) + "' ";
        if (serverName != "") sCondition += " and server.server_name='" + _mysqlReg.escapeString(serverName) + "' ";
        if (withDnsServer == false) sCondition += " and server.server_type !='tars_dns' "; //不获取dns服务

        sSql = "select server.application, server.server_name, server.node_name, base_path, "
               "    exe_path, setting_state, present_state, adapter_name, thread_num, async_thread_num, endpoint,"
               "    profile,template_name, "
               "    allow_ip, max_connections, servant, queuecap, queuetimeout,protocol,handlegroup,"
               "    patch_version, patch_time, patch_user, "
               "    server_type, start_script_path, stop_script_path, monitor_script_path,config_center_port ,"
               "    enable_set, set_name, set_area, set_group "
               "from t_server_conf as server "
               "    left join t_adapter_conf as adapter using(application, server_name, node_name) "
               "where " + sCondition;
```

这一行

```cpp
        if (withDnsServer == false) sCondition += " and server.server_type !='tars_dns' "; //不获取dns服务
```

会把所有`server_type`为`NULL`的记录过滤掉，因为`NULL != 'tars_dns'`的值为`NULL`，是一个false值。

最终，导致 `CDbHandle::getServers()` 函数返回空列表，导致找不到“server description”
